### PR TITLE
Fixed configuration mismatch

### DIFF
--- a/Course Documentation/res/Instructions for Installing VSCode/settings_WINDOWS.json
+++ b/Course Documentation/res/Instructions for Installing VSCode/settings_WINDOWS.json
@@ -37,7 +37,7 @@
         "name": "(gdb) Launch",
         "type": "cppdbg",
         "request": "launch",
-        "program": "${workspaceFolder}/a.exe",
+        "program": "${workspaceFolder}/${fileBasenameNoExtension}.exe",
         "args": [],
         "stopAtEntry": false,
         "cwd": "${workspaceFolder}",


### PR DESCRIPTION
g++ creates "${fileBasenameNoExtension}.exe", but gdb is trying to launch "a.exe"